### PR TITLE
Offline-first improvements for Home/Categories (Hive KV, LRU, image cache, offline banners)

### DIFF
--- a/lib/config/api_config.dart
+++ b/lib/config/api_config.dart
@@ -1,6 +1,6 @@
 class ApiConfig {
   // For local development - make sure your backend server is running on this port
-  static const String baseUrl = 'http://10.0.2.2:8000';
+  static const String baseUrl = 'http://192.168.2.55:8080';
 
   // Alternative configurations:
   // static const String baseUrl = 'http://localhost:8000';  // Alternative local address

--- a/lib/core/strategies/strategy_factory.dart
+++ b/lib/core/strategies/strategy_factory.dart
@@ -51,9 +51,7 @@ class StrategyFactory {
     StrategyFactory.register<PaymentData, PaymentResult>(
       PayPalPaymentStrategy(),
     );
-    StrategyFactory.register<PaymentData, PaymentResult>(
-      CashPaymentStrategy(),
-    );
+    StrategyFactory.register<PaymentData, PaymentResult>(CashPaymentStrategy());
   }
 
   /// Initialize validation strategies
@@ -69,7 +67,9 @@ class StrategyFactory {
       AsyncValidationStrategy<String>(PhoneValidationStrategy()),
     );
     StrategyFactory.register<dynamic, ValidationResult>(
-      AsyncValidationStrategy<Map<String, dynamic>>(UserRegistrationValidationStrategy()),
+      AsyncValidationStrategy<Map<String, dynamic>>(
+        UserRegistrationValidationStrategy(),
+      ),
     );
   }
 
@@ -84,7 +84,14 @@ class StrategyFactory {
     StrategyFactory.register<String, CacheResult<String>>(
       LruMemoryCachingStrategy<String>(
         maxEntries: 256,
-        keyPrefixes: const <String>['orders:', 'order:'],
+        keyPrefixes: const <String>[
+          'orders:',
+          'order:',
+          'home:',
+          'categories:',
+          'category:',
+          'products:',
+        ],
       ),
     );
     StrategyFactory.register<String, CacheResult<String>>(
@@ -169,9 +176,10 @@ class StrategyFactory {
 
   /// Create payment context
   static PaymentContext createPaymentContext() {
-    final strategies = StrategyFactory.getStrategies<PaymentData, PaymentResult>()
-        .cast<PaymentStrategy>();
-    
+    final strategies =
+        StrategyFactory.getStrategies<PaymentData, PaymentResult>()
+            .cast<PaymentStrategy>();
+
     return PaymentContext(
       defaultStrategy: strategies.firstWhere(
         (s) => s.identifier == 'credit_card',
@@ -183,13 +191,15 @@ class StrategyFactory {
 
   /// Create validation context
   static ValidationContext createValidationContext() {
-    final strategies = StrategyFactory.getStrategies<dynamic, ValidationResult>()
-        .cast<Strategy<dynamic, ValidationResult>>();
-    
+    final strategies =
+        StrategyFactory.getStrategies<dynamic, ValidationResult>()
+            .cast<Strategy<dynamic, ValidationResult>>();
+
     return ValidationContext(
       defaultStrategy: strategies.firstWhere(
         (s) => s.identifier == 'email',
-        orElse: () => AsyncValidationStrategy<String>(EmailValidationStrategy()),
+        orElse: () =>
+            AsyncValidationStrategy<String>(EmailValidationStrategy()),
       ),
       strategies: strategies,
     );
@@ -197,9 +207,10 @@ class StrategyFactory {
 
   /// Create cache context
   static CacheContext<String> createCacheContext() {
-    final strategies = StrategyFactory.getStrategies<String, CacheResult<String>>()
-        .cast<CachingStrategy<String>>();
-    
+    final strategies =
+        StrategyFactory.getStrategies<String, CacheResult<String>>()
+            .cast<CachingStrategy<String>>();
+
     return CacheContext<String>(
       defaultStrategy: strategies.firstWhere(
         (s) => s.identifier == 'hybrid',
@@ -211,9 +222,10 @@ class StrategyFactory {
 
   /// Create UI context
   static UIContext createUIContext() {
-    final strategies = StrategyFactory.getStrategies<UIThemeData, UIRenderingResult>()
-        .cast<UIStrategy>();
-    
+    final strategies =
+        StrategyFactory.getStrategies<UIThemeData, UIRenderingResult>()
+            .cast<UIStrategy>();
+
     return UIContext(
       defaultStrategy: strategies.firstWhere(
         (s) => s.identifier == 'material',
@@ -225,9 +237,10 @@ class StrategyFactory {
 
   /// Create error handling context
   static ErrorHandlingContext createErrorHandlingContext() {
-    final strategies = StrategyFactory.getStrategies<Exception, ErrorHandlingResult>()
-        .cast<ErrorHandlingStrategy>();
-    
+    final strategies =
+        StrategyFactory.getStrategies<Exception, ErrorHandlingResult>()
+            .cast<ErrorHandlingStrategy>();
+
     return ErrorHandlingContext(
       defaultStrategy: strategies.firstWhere(
         (s) => s.identifier == 'default',
@@ -238,7 +251,9 @@ class StrategyFactory {
   }
 
   /// Create recommendation context
-  static RecommendationContext createRecommendationContext(GetRecommendedProductsUseCase useCase) {
+  static RecommendationContext createRecommendationContext(
+    GetRecommendedProductsUseCase useCase,
+  ) {
     final popularityStrategy = PopularityRecommendationStrategy(useCase);
     final categoryStrategy = CategoryRecommendationStrategy(useCase);
     final mixedStrategy = MixedRecommendationStrategy(
@@ -254,9 +269,13 @@ class StrategyFactory {
 
   /// Create currency display context
   static CurrencyDisplayContext createCurrencyDisplayContext() {
-    final strategies = StrategyFactory.getStrategies<CurrencyDisplayRequest, CurrencyDisplayResult>()
-        .cast<CurrencyDisplayStrategy>();
-    
+    final strategies =
+        StrategyFactory.getStrategies<
+              CurrencyDisplayRequest,
+              CurrencyDisplayResult
+            >()
+            .cast<CurrencyDisplayStrategy>();
+
     return CurrencyDisplayContext(
       defaultStrategy: strategies.firstWhere(
         (s) => s.identifier == 'international_focus',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,10 @@ import 'di/injector.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  // Tune in-memory image cache (acts like NSCache for images)
+  PaintingBinding.instance.imageCache.maximumSize = 300; // number of images
+  PaintingBinding.instance.imageCache.maximumSizeBytes =
+      150 * 1024 * 1024; // ~150MB
   await setupDependencies();
   runApp(const MyApp());
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'categories_page.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../services/image_cache_manager.dart';
+import '../widgets/offline_notice.dart';
 import 'products_by_category_page.dart';
 import '../widgets/recommendations_widget.dart';
 
@@ -49,6 +52,7 @@ class HomePage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
+            const OfflineNotice(),
             _SearchBar(colors: colors),
             const SizedBox(height: 16),
             _Promotions(promotions: _promotions),
@@ -66,10 +70,7 @@ class HomePage extends StatelessWidget {
             const SizedBox(height: 8),
             _CategoriesList(categories: _categories),
             const SizedBox(height: 16),
-            const RecommendationsWidget(
-              title: 'Recommended for You',
-              limit: 5,
-            ),
+            const RecommendationsWidget(title: 'Recommended for You', limit: 5),
             const SizedBox(height: 16),
             _SectionHeader(title: 'Near Me'),
             const SizedBox(height: 8),
@@ -128,26 +129,22 @@ class _Promotions extends StatelessWidget {
                 Expanded(
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(12),
-                    child: Image.network(
-                      promo['image']!,
+                    child: CachedNetworkImage(
+                      imageUrl: promo['image']!,
+                      cacheKey: 'img:banner:${promo['image']}',
+                      cacheManager: AppImageCacheManagers.banners,
                       width: double.infinity,
                       fit: BoxFit.cover,
-                      loadingBuilder:
-                          (
-                            BuildContext context,
-                            Widget child,
-                            ImageChunkEvent? progress,
-                          ) {
-                            if (progress == null) return child;
-                            return Container(
-                              color: Colors.black12,
-                              child: const Center(
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
-                              ),
-                            );
-                          },
+                      memCacheWidth: 800,
+                      memCacheHeight: 400,
+                      placeholder: (_, __) => Container(
+                        color: Colors.black12,
+                        child: const Center(
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      ),
+                      errorWidget: (_, __, ___) =>
+                          const Icon(Icons.broken_image),
                     ),
                   ),
                 ),
@@ -261,11 +258,17 @@ class _NearbyList extends StatelessWidget {
             const SizedBox(width: 12),
             ClipRRect(
               borderRadius: BorderRadius.circular(8),
-              child: Image.network(
-                v.imageUrl,
+              child: CachedNetworkImage(
+                imageUrl: v.imageUrl,
+                cacheKey: 'img:venue:${v.imageUrl}',
+                cacheManager: AppImageCacheManagers.productImages,
                 width: 120,
                 height: 84,
                 fit: BoxFit.cover,
+                memCacheWidth: 360,
+                memCacheHeight: 252,
+                placeholder: (_, __) => Container(color: Colors.black12),
+                errorWidget: (_, __, ___) => const Icon(Icons.broken_image),
               ),
             ),
           ],

--- a/lib/pages/products_by_category_page.dart
+++ b/lib/pages/products_by_category_page.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import '../services/cart_service.dart';
 import '../core/result.dart';
 import '../domain/entities/product.dart';
 import '../domain/usecases/get_products_by_category_usecase.dart';
 import '../core/strategies/error_handling_strategy.dart';
 import '../di/injector.dart';
+import '../services/image_cache_manager.dart';
+import '../services/local_catalog_storage.dart';
+import '../widgets/offline_notice.dart';
 
 class ProductsByCategoryPage extends StatefulWidget {
   const ProductsByCategoryPage({
@@ -40,6 +44,39 @@ class _ProductsByCategoryPageState extends State<ProductsByCategoryPage> {
       _error = null;
     });
 
+    // Fast path: try cached page first
+    try {
+      final cached = await LocalCatalogStorage.instance.readCategoryPage(
+        categoryId: widget.categoryId,
+        page: 1,
+      );
+      if (cached.isNotEmpty && mounted) {
+        setState(() {
+          _products = cached
+              .map(
+                (m) => ProductEntity(
+                  id: (m['id'] as num?)?.toInt() ?? 0,
+                  typeId:
+                      (m['typeId'] as num?)?.toInt() ??
+                      (m['id_tipo'] as num?)?.toInt() ??
+                      0,
+                  name: (m['name'] ?? m['nombre'] ?? '').toString(),
+                  description: (m['description'] ?? m['descripcion'] ?? '')
+                      .toString(),
+                  imageUrl:
+                      (m['imageUrl'] ?? m['imagen_url'] ?? m['imagen'] ?? '')
+                          .toString(),
+                  price: ((m['price'] ?? m['precio'] ?? 0) as num).toDouble(),
+                  available:
+                      (m['available'] ?? m['disponible'] ?? true) as bool,
+                ),
+              )
+              .toList(growable: false);
+          _loading = false;
+        });
+      }
+    } catch (_) {}
+
     try {
       final GetProductsByCategoryUseCase useCase = GetIt.I
           .get<GetProductsByCategoryUseCase>();
@@ -55,6 +92,26 @@ class _ProductsByCategoryPageState extends State<ProductsByCategoryPage> {
           _products = items;
           _loading = false;
         });
+        // Persist to local cache for quick reopen
+        final raw = items
+            .map(
+              (p) => <String, dynamic>{
+                'id': p.id,
+                'id_tipo': p.typeId,
+                'name': p.name,
+                'description': p.description,
+                'imageUrl': p.imageUrl,
+                'price': p.price,
+                'available': p.available,
+              },
+            )
+            .toList(growable: false);
+        // ignore: discarded_futures
+        LocalCatalogStorage.instance.saveCategoryPage(
+          categoryId: widget.categoryId,
+          page: 1,
+          products: raw,
+        );
       } else {
         String friendly = result.error ?? 'Unable to load products';
         try {
@@ -88,7 +145,15 @@ class _ProductsByCategoryPageState extends State<ProductsByCategoryPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text(widget.categoryName)),
-      body: _buildBody(),
+      body: Column(
+        children: <Widget>[
+          const Padding(
+            padding: EdgeInsets.fromLTRB(12, 12, 12, 0),
+            child: OfflineNotice(),
+          ),
+          Expanded(child: _buildBody()),
+        ],
+      ),
     );
   }
 
@@ -96,6 +161,130 @@ class _ProductsByCategoryPageState extends State<ProductsByCategoryPage> {
     if (_loading) {
       return const Center(child: CircularProgressIndicator());
     }
+    // If we have products, prefer showing them even if there was an error later
+    if (_products.isNotEmpty) {
+      return ListView.separated(
+        padding: const EdgeInsets.all(12),
+        itemCount: _products.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemBuilder: (BuildContext context, int index) {
+          final ProductEntity p = _products[index];
+          final String nombre = p.name;
+          final String descripcion = p.description;
+          final String imagenUrl = p.imageUrl;
+          final double precio = p.price;
+          final bool disponible = p.available;
+
+          return Card(
+            clipBehavior: Clip.antiAlias,
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Row(
+                children: <Widget>[
+                  SizedBox(
+                    width: 110,
+                    height: 90,
+                    child: imagenUrl.isEmpty
+                        ? Container(
+                            color: Colors.grey[300],
+                            child: const Icon(Icons.image_outlined),
+                          )
+                        : (imagenUrl.startsWith('http')
+                              ? CachedNetworkImage(
+                                  imageUrl: imagenUrl,
+                                  cacheKey: 'img:product:$imagenUrl',
+                                  cacheManager:
+                                      AppImageCacheManagers.productImages,
+                                  width: 110,
+                                  height: 90,
+                                  fit: BoxFit.cover,
+                                  memCacheWidth: 256,
+                                  memCacheHeight: 210,
+                                  placeholder: (_, __) =>
+                                      Container(color: Colors.black12),
+                                  errorWidget: (_, __, ___) =>
+                                      const Icon(Icons.broken_image),
+                                )
+                              : Image.asset(
+                                  imagenUrl,
+                                  width: 110,
+                                  height: 90,
+                                  fit: BoxFit.cover,
+                                )),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          nombre,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          descripcion,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                        const SizedBox(height: 6),
+                        Row(
+                          children: <Widget>[
+                            Text(
+                              '\$${precio.toStringAsFixed(2)}',
+                              style: Theme.of(context).textTheme.titleSmall,
+                            ),
+                            const Spacer(),
+                            IconButton(
+                              tooltip: 'Add to cart',
+                              onPressed: disponible
+                                  ? () {
+                                      CartService.instance.addOrIncrement(
+                                        productId: p.id,
+                                        name: nombre,
+                                        imageUrl: imagenUrl,
+                                        unitPrice: precio,
+                                      );
+                                      ScaffoldMessenger.of(
+                                        context,
+                                      ).showSnackBar(
+                                        const SnackBar(
+                                          content: Text('Added to cart'),
+                                        ),
+                                      );
+                                    }
+                                  : null,
+                              icon: const Icon(
+                                Icons.add_shopping_cart_outlined,
+                              ),
+                            ),
+                          ],
+                        ),
+                        if (!disponible)
+                          const Padding(
+                            padding: EdgeInsets.only(top: 4),
+                            child: Align(
+                              alignment: Alignment.centerLeft,
+                              child: Chip(
+                                label: Text('Unavailable'),
+                                visualDensity: VisualDensity.compact,
+                                materialTapTargetSize:
+                                    MaterialTapTargetSize.shrinkWrap,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      );
+    }
+
     if (_error != null) {
       return Padding(
         padding: const EdgeInsets.all(16),
@@ -110,116 +299,7 @@ class _ProductsByCategoryPageState extends State<ProductsByCategoryPage> {
       );
     }
 
-    if (_products.isEmpty) {
-      return const Center(child: Text('No products found.'));
-    }
-
-    return ListView.separated(
-      padding: const EdgeInsets.all(12),
-      itemCount: _products.length,
-      separatorBuilder: (_, __) => const SizedBox(height: 12),
-      itemBuilder: (BuildContext context, int index) {
-        final ProductEntity p = _products[index];
-        final String nombre = p.name;
-        final String descripcion = p.description;
-        final String imagenUrl = p.imageUrl;
-        final double precio = p.price;
-        final bool disponible = p.available;
-
-        return Card(
-          clipBehavior: Clip.antiAlias,
-          child: Padding(
-            padding: const EdgeInsets.all(8),
-            child: Row(
-              children: <Widget>[
-                SizedBox(
-                  width: 110,
-                  height: 90,
-                  child: imagenUrl.isEmpty
-                      ? Container(
-                          color: Colors.grey[300],
-                          child: const Icon(Icons.image_outlined),
-                        )
-                      : (imagenUrl.startsWith('http')
-                          ? Image.network(
-                              imagenUrl,
-                              width: 110,
-                              height: 90,
-                              fit: BoxFit.cover,
-                            )
-                          : Image.asset(
-                              imagenUrl,
-                              width: 110,
-                              height: 90,
-                              fit: BoxFit.cover,
-                            )),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        nombre,
-                        style: Theme.of(context).textTheme.titleMedium,
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        descripcion,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.bodySmall,
-                      ),
-                      const SizedBox(height: 6),
-                      Row(
-                        children: <Widget>[
-                          Text(
-                            '\$${precio.toStringAsFixed(2)}',
-                            style: Theme.of(context).textTheme.titleSmall,
-                          ),
-                          const Spacer(),
-                          IconButton(
-                            tooltip: 'Add to cart',
-                            onPressed: disponible
-                                ? () {
-                                    CartService.instance.addOrIncrement(
-                                      productId: p.id,
-                                      name: nombre,
-                                      imageUrl: imagenUrl,
-                                      unitPrice: precio,
-                                    );
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      const SnackBar(
-                                        content: Text('Added to cart'),
-                                      ),
-                                    );
-                                  }
-                                : null,
-                            icon: const Icon(Icons.add_shopping_cart_outlined),
-                          ),
-                        ],
-                      ),
-                      if (!disponible)
-                        const Padding(
-                          padding: EdgeInsets.only(top: 4),
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Chip(
-                              label: Text('Unavailable'),
-                              visualDensity: VisualDensity.compact,
-                              materialTapTargetSize:
-                                  MaterialTapTargetSize.shrinkWrap,
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
+    // Empty state
+    return const Center(child: Text('No products found.'));
   }
 }

--- a/lib/services/image_cache_manager.dart
+++ b/lib/services/image_cache_manager.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+class AppImageCacheManagers {
+  AppImageCacheManagers._();
+
+  static final BaseCacheManager banners = CacheManager(
+    Config(
+      'bannersCache',
+      stalePeriod: const Duration(days: 7),
+      maxNrOfCacheObjects: 150,
+      repo: JsonCacheInfoRepository(databaseName: 'bannersCache'),
+      fileService: HttpFileService(),
+    ),
+  );
+
+  static final BaseCacheManager productImages = CacheManager(
+    Config(
+      'productImagesCache',
+      stalePeriod: const Duration(days: 2),
+      maxNrOfCacheObjects: 400,
+      repo: JsonCacheInfoRepository(databaseName: 'productImagesCache'),
+      fileService: HttpFileService(),
+    ),
+  );
+}

--- a/lib/services/local_catalog_storage.dart
+++ b/lib/services/local_catalog_storage.dart
@@ -1,0 +1,182 @@
+import 'dart:convert';
+import 'package:hive_flutter/hive_flutter.dart';
+
+class _Keys {
+  // Home
+  static const String homeFeed = 'home:feed:v1';
+  static const String homeLayout = 'home:layout:v1';
+  static const String homeRecommended = 'home:recommended:v1';
+
+  // Categories
+  static const String categoriesList = 'categories:list:v1';
+  static String categoryPage(int categoryId, int page) =>
+      'category:$categoryId:products:page:$page:v1';
+  static String categoryRecommended(int categoryId) =>
+      'category:$categoryId:recommended:v1';
+}
+
+/// Local storage for catalog data (home feed, categories, products per category)
+class LocalCatalogStorage {
+  LocalCatalogStorage._();
+  static final LocalCatalogStorage instance = LocalCatalogStorage._();
+
+  static const String _boxName = 'catalog';
+
+  Future<Box<String>> _box() async {
+    if (!Hive.isBoxOpen(_boxName)) {
+      await Hive.openBox<String>(_boxName);
+    }
+    return Hive.box<String>(_boxName);
+  }
+
+  Future<void> _put(String key, String data, Duration ttl) async {
+    final box = await _box();
+    final int expiresAt = DateTime.now().add(ttl).millisecondsSinceEpoch;
+    final String envelope = jsonEncode(<String, dynamic>{
+      'data': data,
+      'exp': expiresAt,
+    });
+    await box.put(key, envelope);
+  }
+
+  Future<String?> _get(String key) async {
+    final box = await _box();
+    final String? envelope = box.get(key);
+    if (envelope == null || envelope.isEmpty) return null;
+    try {
+      final Map<String, dynamic> m =
+          jsonDecode(envelope) as Map<String, dynamic>;
+      final int exp = (m['exp'] ?? 0) as int;
+      if (exp > 0 && DateTime.now().millisecondsSinceEpoch > exp) {
+        await box.delete(key);
+        return null;
+      }
+      final String data = (m['data'] ?? '') as String;
+      return data.isEmpty ? null : data;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // Home feed/layout
+  Future<void> saveHomeFeed(Map<String, dynamic> feed) async {
+    await _put(_Keys.homeFeed, jsonEncode(feed), const Duration(minutes: 30));
+  }
+
+  Future<Map<String, dynamic>?> readHomeFeed() async {
+    final String? raw = await _get(_Keys.homeFeed);
+    if (raw == null) return null;
+    try {
+      return jsonDecode(raw) as Map<String, dynamic>;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> saveHomeLayout(Map<String, dynamic> layout) async {
+    await _put(
+      _Keys.homeLayout,
+      jsonEncode(layout),
+      const Duration(minutes: 30),
+    );
+  }
+
+  Future<Map<String, dynamic>?> readHomeLayout() async {
+    final String? raw = await _get(_Keys.homeLayout);
+    if (raw == null) return null;
+    try {
+      return jsonDecode(raw) as Map<String, dynamic>;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // Categories list
+  Future<void> saveCategoriesList(List<Map<String, dynamic>> categories) async {
+    await _put(
+      _Keys.categoriesList,
+      jsonEncode(categories),
+      const Duration(minutes: 30),
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> readCategoriesList() async {
+    final String? raw = await _get(_Keys.categoriesList);
+    if (raw == null) return <Map<String, dynamic>>[];
+    try {
+      final decoded = jsonDecode(raw) as List<dynamic>;
+      return decoded.cast<Map<String, dynamic>>();
+    } catch (_) {
+      return <Map<String, dynamic>>[];
+    }
+  }
+
+  // Products by category page
+  Future<void> saveCategoryPage({
+    required int categoryId,
+    required int page,
+    required List<Map<String, dynamic>> products,
+    Duration ttl = const Duration(minutes: 10),
+  }) async {
+    await _put(_Keys.categoryPage(categoryId, page), jsonEncode(products), ttl);
+  }
+
+  Future<List<Map<String, dynamic>>> readCategoryPage({
+    required int categoryId,
+    required int page,
+  }) async {
+    final String? raw = await _get(_Keys.categoryPage(categoryId, page));
+    if (raw == null) return <Map<String, dynamic>>[];
+    try {
+      final decoded = jsonDecode(raw) as List<dynamic>;
+      return decoded.cast<Map<String, dynamic>>();
+    } catch (_) {
+      return <Map<String, dynamic>>[];
+    }
+  }
+
+  // Recommendations (generic)
+  Future<void> saveHomeRecommended(List<Map<String, dynamic>> products) async {
+    await _put(
+      _Keys.homeRecommended,
+      jsonEncode(products),
+      const Duration(minutes: 30),
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> readHomeRecommended() async {
+    final String? raw = await _get(_Keys.homeRecommended);
+    if (raw == null) return <Map<String, dynamic>>[];
+    try {
+      final decoded = jsonDecode(raw) as List<dynamic>;
+      return decoded.cast<Map<String, dynamic>>();
+    } catch (_) {
+      return <Map<String, dynamic>>[];
+    }
+  }
+
+  // Recommendations by category
+  Future<void> saveCategoryRecommended({
+    required int categoryId,
+    required List<Map<String, dynamic>> products,
+  }) async {
+    await _put(
+      _Keys.categoryRecommended(categoryId),
+      jsonEncode(products),
+      const Duration(minutes: 30),
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> readCategoryRecommended({
+    required int categoryId,
+  }) async {
+    final String? raw = await _get(_Keys.categoryRecommended(categoryId));
+    if (raw == null) return <Map<String, dynamic>>[];
+    try {
+      final decoded = jsonDecode(raw) as List<dynamic>;
+      return decoded.cast<Map<String, dynamic>>();
+    } catch (_) {
+      return <Map<String, dynamic>>[];
+    }
+  }
+}

--- a/lib/widgets/offline_notice.dart
+++ b/lib/widgets/offline_notice.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import '../services/connectivity_service.dart';
+
+class OfflineNotice extends StatefulWidget {
+  const OfflineNotice({super.key});
+
+  @override
+  State<OfflineNotice> createState() => _OfflineNoticeState();
+}
+
+class _OfflineNoticeState extends State<OfflineNotice> {
+  bool _online = true;
+  StreamSubscription<bool>? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialize (idempotent)
+    // ignore: discarded_futures
+    ConnectivityService.instance.initialize();
+    _online = ConnectivityService.instance.isOnline;
+    _sub = ConnectivityService.instance.online$.listen((bool online) {
+      if (!mounted) return;
+      setState(() {
+        _online = online;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_online) return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.all(12),
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: BoxDecoration(
+        color: Colors.orange.withOpacity(0.15),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.orange),
+      ),
+      child: const Row(
+        children: <Widget>[
+          Icon(Icons.wifi_off, color: Colors.orange),
+          SizedBox(width: 8),
+          Expanded(child: Text('You are offline. Showing cached content.')),
+        ],
+      ),
+    );
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,14 +5,18 @@
 import FlutterMacOS
 import Foundation
 
+import connectivity_plus
 import file_selector_macos
 import path_provider_foundation
 import screen_brightness_macos
 import shared_preferences_foundation
+import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -153,11 +177,27 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3+4"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: "direct main"
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -376,6 +416,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   path:
     dependency: "direct main"
     description:
@@ -472,6 +520,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   screen_brightness:
     dependency: "direct main"
     description:
@@ -589,6 +645,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   sqflite:
     dependency: "direct main"
     description:
@@ -685,6 +749,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,8 @@ dependencies:
   connectivity_plus: ^6.0.5
   hive: ^2.2.3
   hive_flutter: ^1.1.0
+  cached_network_image: ^3.3.1
+  flutter_cache_manager: ^3.3.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <screen_brightness_windows/screen_brightness_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   ScreenBrightnessWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   file_selector_windows
   screen_brightness_windows
 )


### PR DESCRIPTION
Improves offline behavior and caching for Home and Categories:
- Uses Hive for key/value catalog data with TTL
- Adds robust image caching (disk + memory)
- Extends LRU prefixes for catalog keys
- Displays per-screen offline banners and continues navigation with cached data

Key changes:
-LocalCatalogStorage migrated to Hive with TTL envelopes (home feed/layout, categories list, category pages, recommendations)
-Image caching via cached_network_image + dedicated CacheManagers for banners and product images
-ImageCache limits tuned (~300 images, ~150MB)
-LRU key prefixes extended for home/categories/category/products
-OfflineNotice component added and integrated into Home and ProductsByCategory
-ProductsByCategory prioritizes cached list when network fails; Recommendations read cache first and persist after success