### PR TITLE
Add profile caching and enhance profile page with offline support

### DIFF
--- a/lib/core/strategies/strategy_factory.dart
+++ b/lib/core/strategies/strategy_factory.dart
@@ -91,6 +91,7 @@ class StrategyFactory {
           'categories:',
           'category:',
           'products:',
+          'profile:',
         ],
       ),
     );

--- a/lib/di/injector.dart
+++ b/lib/di/injector.dart
@@ -113,11 +113,12 @@ Future<void> setupDependencies() async {
   injector.registerLazySingleton(() => StrategyFactory.createCurrencyDisplayContext());
 
   // Services
-  injector.registerLazySingleton<MemoryCachingStrategy<String>>(
-    () => MemoryCachingStrategy<String>(maxSize: 16),
+  // Use SharedPreferences-backed cache for auth form drafts so they persist across sessions
+  injector.registerLazySingleton<PreferencesCachingStrategy>(
+    () => PreferencesCachingStrategy(),
   );
   injector.registerLazySingleton<FormCacheService>(
-    () => FormCacheService(injector.get<MemoryCachingStrategy<String>>()),
+    () => FormCacheService(injector.get<PreferencesCachingStrategy>()),
   );
   final ProfileLocalStorage profileLocalStorage = ProfileLocalStorage();
   await profileLocalStorage.init();


### PR DESCRIPTION
Implemented Sprint 3 improvements: enhanced API timeouts for clearer failures, switched login/registration drafts to persistent shared-preferences caching, and added profile caching (LRU in-memory + existing SQLite fallback) with better offline messaging.